### PR TITLE
fix: add key to mapped items

### DIFF
--- a/src/components/ResourceHeader/index.tsx
+++ b/src/components/ResourceHeader/index.tsx
@@ -74,7 +74,7 @@ export function ResourceHeader({
         <SC.RecommendedReading>
           Recommended reading
           {recommendedReading.map(item => {
-            return <ExtraLink item={item} />
+            return <ExtraLink key={item} item={item} />
           })}
         </SC.RecommendedReading>
       )}
@@ -83,7 +83,7 @@ export function ResourceHeader({
         <SC.ExternalResources>
           External Resources
           {externalResources.map(item => {
-            return <ExtraLink item={item} external />
+            return <ExtraLink key={item} item={item} external />
           })}
         </SC.ExternalResources>
       )}

--- a/src/components/StackedAvatars/index.tsx
+++ b/src/components/StackedAvatars/index.tsx
@@ -10,7 +10,7 @@ export function StackedAvatars({ authors }: StackedAvatarsProps) {
   return (
     <SC.StackedAvatarsWrapper count={authors.length}>
       {authors.map((author, index) => (
-        <SC.AuthorAvatar src={author.avatar} index={index} />
+        <SC.AuthorAvatar key={index} src={author.avatar} index={index} />
       ))}
     </SC.StackedAvatarsWrapper>
   )


### PR DESCRIPTION
No real harm here, just very annoying to get the warning during development, and a best practice.