### PR TITLE
feat: capitalize breadcrumbs

### DIFF
--- a/src/components/ResourceBreadcrumb/index.tsx
+++ b/src/components/ResourceBreadcrumb/index.tsx
@@ -1,3 +1,4 @@
+import pipe from "ramda/es/pipe"
 import React from "react"
 
 import ChevronUp from "../../icons/chevron-up.svg"
@@ -16,8 +17,19 @@ function capitalize(str: string): string {
     .join(" ")
 }
 
+function dashToSpace(str: string): string {
+  return str.replace("-", " ")
+}
+
+function humanize(str: string): string {
+  return pipe(
+    dashToSpace,
+    capitalize
+  )(str)
+}
+
 function Link({ item }: { item: IFileOrFolder }) {
-  return <SC.StyledLink to={item.path}>{capitalize(item.title)}</SC.StyledLink>
+  return <SC.StyledLink to={item.path}>{humanize(item.title)}</SC.StyledLink>
 }
 
 function flatten([

--- a/src/components/ResourceBreadcrumb/index.tsx
+++ b/src/components/ResourceBreadcrumb/index.tsx
@@ -10,12 +10,10 @@ interface IResourceBreadcrumbProps {
 }
 
 function capitalize(str: string): string {
-  const split = str.split(" ")
-  const reconstruct = []
-  for (const substr of split) {
-    reconstruct.push(`${substr.charAt(0).toUpperCase()}${substr.substring(1)}`)
-  }
-  return reconstruct.join(" ")
+  return str
+    .split(" ")
+    .map(word => `${word.charAt(0).toUpperCase()}${word.substring(1)}`)
+    .join(" ")
 }
 
 function Link({ item }: { item: IFileOrFolder }) {

--- a/src/components/ResourceBreadcrumb/index.tsx
+++ b/src/components/ResourceBreadcrumb/index.tsx
@@ -9,8 +9,17 @@ interface IResourceBreadcrumbProps {
   relativePath: any
 }
 
+function capitalize(str: string): string {
+  const split = str.split(" ")
+  const reconstruct = []
+  for (const substr of split) {
+    reconstruct.push(`${substr.charAt(0).toUpperCase()}${substr.substring(1)}`)
+  }
+  return reconstruct.join(" ")
+}
+
 function Link({ item }: { item: IFileOrFolder }) {
-  return <SC.StyledLink to={item.path}>{item.title}</SC.StyledLink>
+  return <SC.StyledLink to={item.path}>{capitalize(item.title)}</SC.StyledLink>
 }
 
 function flatten([
@@ -30,6 +39,23 @@ export function ResourceBreadcrumb({ relativePath }: IResourceBreadcrumbProps) {
 
   return (
     <SC.ResourceBreadcrumbWrapper>
+      <SC.LinkWrapper>
+        <Link
+          item={{ path: "/", title: "Home", type: "folder", children: [] }}
+        />
+        <ChevronUp />
+      </SC.LinkWrapper>
+      <SC.LinkWrapper>
+        <Link
+          item={{
+            path: "/resources",
+            title: "Resources",
+            type: "folder",
+            children: [],
+          }}
+        />
+        <ChevronUp />
+      </SC.LinkWrapper>
       {breadcrumbItems.map(item => {
         if (item.type === "folder") {
           return (


### PR DESCRIPTION
Partly cherry-picked from #63.

Refactored into functional, and removed dashes in route name.

Next up would be:
1. converting some specific words into capital: PHP, PDO.
2. converting the name of the page (Title Cased?)
3. possible treating over name of the page, for example, words like `vs`, or articles like `the`, in Title Case should not be capitalized.

Xetera judge my Ramda usage.
Re: @Xetera and @aerori 

Do we want /Home/Resources in the breadcrumbs? My first implementation of breadcrumbs skipped them as I found them very verbose (and saw no real benefit to head back to home).

Follow up @ #68

Deploy preview: https://deploy-preview-67--tph.netlify.com/resources/javascript/iterative-vs-functional.md