### PR TITLE
feat: default to darkmode instead of lightmode

### DIFF
--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -17,7 +17,7 @@ interface IScopedDownChildren {
 export const ThemeContext = createContext<IThemeContext | null>(null)
 
 const ThemeProvider: FC<IScopedDownChildren> = ({ children }) => {
-  const [theme, setTheme] = useLocalStorage("theme", "light")
+  const [theme, setTheme] = useLocalStorage("theme", "dark")
 
   const themeObject = useMemo(
     () => (theme === "dark" ? darkTheme : lightTheme),


### PR DESCRIPTION
90%+ of Discord users seem to prefer darkmode, so it makes sense to default to it.