### PR TITLE
resource: fix broken links in js promise article

### DIFF
--- a/src/content/resources/javascript/promises/intro.md
+++ b/src/content/resources/javascript/promises/intro.md
@@ -5,7 +5,7 @@ created_at: 2019/07/26
 updated_at: 2019/07/26
 title: Introduction to Promises
 recommended_reading:
-  - javascript/callbacks
+  - javascript/callbacks/intro
   - javascript/es6/arrow-functions
 ---
 


### PR DESCRIPTION
Fix broken links in Promise JS article.

Before, these links sent the user to a 404, and now the callbacks one works correctly and the arrow functions link was removed (as this article doesn't exist).