### PR TITLE
ui(resources): style markdown links

### DIFF
--- a/src/components/Markdown/styles.tsx
+++ b/src/components/Markdown/styles.tsx
@@ -1,3 +1,4 @@
+import { darken, lighten } from "polished"
 import styled, { css } from "styled-components"
 import {
   BASE_FONT_SIZE,
@@ -92,6 +93,18 @@ export const MarkdownWrapper = styled.div`
     .token.keyword,
     .token.builtin {
       color: #d1529d;
+    }
+  }
+
+  a {
+    color: ${props => props.theme.main.link};
+    cursor: pointer;
+
+    &:hover {
+      color: ${props =>
+        props.theme.name === "dark"
+          ? lighten(0.15, props.theme.main.link)
+          : darken(0.15, props.theme.main.link)};
     }
   }
 `


### PR DESCRIPTION
It was especially bad in dark mode:

![image](https://user-images.githubusercontent.com/3461986/66304814-0cf70b00-e8cc-11e9-9e80-2813cd2fbc0c.png)

Now:

![image](https://user-images.githubusercontent.com/3461986/66304834-1aac9080-e8cc-11e9-85f2-c259e712d990.png)
