### PR TITLE
#143 Resources: very long links and wide images break mobile

### DIFF
--- a/src/components/Markdown/styles.tsx
+++ b/src/components/Markdown/styles.tsx
@@ -96,6 +96,10 @@ export const MarkdownWrapper = styled.div`
     padding: 0;
   }
 
+  img {
+    max-width: 100%;
+  }
+
   pre[class*="language-"] {
     .token.boolean,
     .token.number,
@@ -119,6 +123,7 @@ export const MarkdownWrapper = styled.div`
   }
 
   a {
+    word-break: break-all;
     color: ${props => props.theme.main.link};
     cursor: pointer;
 


### PR DESCRIPTION
updated css for image and anchor tags

closes #143 

![image](https://user-images.githubusercontent.com/3828145/67097478-c7501180-f1ec-11e9-935f-27ecbb3b96e9.png)
