### PR TITLE
Fixed Discord Tag

### DIFF
--- a/src/content/resources/javascript/es6/arrow-functions.md
+++ b/src/content/resources/javascript/es6/arrow-functions.md
@@ -1,6 +1,6 @@
 ---
 authors:
-  - "t0m#5956"
+  - "T0M#5956"
 created_at: 2019/10/08
 updated_at: 2019/10/13
 title: Arrow functions


### PR DESCRIPTION
Fixed discord tag on the arrow functions article, as discord tags are case-sensitive. The tag should now be accurate. This should fix the profile picture not appearing on the article.