### PR TITLE
fix(rules): fix rule links and formatting

### DIFF
--- a/src/content/site/rules.md
+++ b/src/content/site/rules.md
@@ -7,74 +7,74 @@ path: /rules
 - [General Rules](#general-rules)
 - [Golden Rules](#golden-rules)
 - [Content Policy](#content-policy)
-- [Why isn't security talk allowed?](#Why-dont-you-allow-talk-regarding-hacking)
+- [Why isn't security talk allowed?](#why-dont-you-allow-talk-regarding-hacking)
 - [Server Roles](#roles)
-- [Nickname Policy](#Nickname-Policy)
-- [What is Modmail / How to contact staff](#What-is-ModMail)
+- [Nickname Policy](#nickname-policy)
+- [What is Modmail / How to contact staff](#what-is-modmail)
 
 # General Rules
 
 Below you will find the rules of the server. These are the do's and don'ts of being here. Follow them if you wish to stay, ignorance is not an excuse.
 
-**1. Do not advertise.**
+**1. Do not advertise.**<br />
 This includes other servers, products or services that you stand to benefit from financially, your Youtube channel or the like.
 
-**2. Do not be a dick.**
+**2. Do not be a dick.**<br />
 If you make yourself particularly hard to deal with, if you pretend that you are better than anyone else, or if you are just in general very annoying and not a good fit for this server we will remove you. Permanently.
 
-**3. Use facts, not authority.**
+**3. Use facts, not authority.**<br />
 If you are going to provide anecdote or your own experience, that is fine, provided you don't pass it off as axiomatic. Quote sources when you are asked to.
 
-**4. Do not flame languages or other such technologies (e.g. text editors).**
+**4. Do not flame languages or other such technologies (e.g. text editors).**<br />
 Doing so is reductive. If someone likes to use VB.Net or JavaScript or Vim, we surprisingly expect you to not jump down their throat about that. Doing so outside of regulated channels where staff have explicitly allowed the discussion for a short period of time is not allowed ( #poll-discussion is one such example of an okay place to talk about it provided the poll allows it )
 
-**5. Speak English only in the chat.**
+**5. Speak English only in the chat.**<br />
 This speaks for itself, we do not expect staff to speak extra languages and we cannot moderate what we do not understand. Sorry.
 
-**6. Do not ask for free work.**
+**6. Do not ask for free work.**<br />
 This is not an advertisement platform. If you are going to take from this community, you are going to give back to it first. We do not care about your work if you do not care about us. Thanks.
 
-**7. Do not DM people who you have not built a rapport with.**
+**7. Do not DM people who you have not built a rapport with.**<br />
 This is self explanatory. Don't be a creep. Don't be a pest, ask questions in relevant channels. Someone's DM is not a relevant channel.
 
-**8. Do not talk about your infractions publicly.**
+**8. Do not talk about your infractions publicly.**<br />
 If you are infracted, it's not a big deal. It's simply a formal warning - you can totally recover from that. If you disagree with a warning, DM @ModMail. Complaining about infractions publicly will land you a mute or a ban. Don't pollute chat or other channels with these conversations.
 
-**9. Do not participate in spoonfeeding.**
+**9. Do not participate in spoonfeeding.**<br />
 Asking to be spoonfed is the same as asking someone else to do your work for you. We do not condone just solving the problems of others -- make them work for it. Give a man a fish and you feed him for a day. Teach a man to fish and you feed him for a lifetime.
 
-**10. Do not impersonate staff members**
+**10. Do not impersonate staff members.**<br />
 Using the avatar of another staff member that they've had for a reasonable long time is not allowed. You will be notified if you seem like you're impersonating a staff member. We may also nickname you depending on context. In addition, it is especially prohibited to pretend to be another staff member through messages/voice, DM or otherwise. Doing so will land you an immediate, permanent ban.
 
-**11. Follow the directions of staff members to the letter**
+**11. Follow the directions of staff members to the letter.**<br />
 Most of us are here for our love of programming, so we like to do as much talking about programming and the like as possible. That being said, we really don't like intervening. But we especially don't like having to intervene twice. Please don't make us do that, thank you
 
-**12. No backseat driving**
+**12. No backseat driving.**<br />
 If you see people working through a problem, you shouldn't intermittently interject advice. Let them work it out unless someone asks for help. We understand you want to help out, but this can often cause confusion and overall a negative impact on the person who originally asked the question.
 
-**13. Do not bad mouth linked servers**
+**13. Do not bad mouth linked servers.**<br />
 TPH is joined at the hip to Controversy Central (CC), KUtils, and Late Gaming (LG). If you don't like one of our linked servers, just leave them. Each server serves its own purpose.
 
-**14. TPH is not a ban appeal vector for linked servers**
+**14. TPH is not a ban appeal vector for linked servers.**<br />
 Bans on all linked servers are propagated. This means that if you are banned on any of our servers (CC/KUtils/Late Gaming), you will be banned on all of them. Members with certain roles will be exempt from ban propagation, but that is no excuse to run riot on other servers. If you troll them, we will also ban you here. That being said, TPH is not a place to post your ban appeal. Please take it up with those servers.
 
-**15. Link to the FAQ and beginner guide channels liberally**
+**15. Link to the FAQ and beginner guide channels liberally.**<br />
 The FAQ and beginner guide channels represent many hours of discussion to find well rounded answers to common questions. Please link to them regularly when beginners and the uninformed ask those questions. You may be asked to cease your participation in a conversation if you present yourself as a zealot with distracting opinions.
 
 [Table of Contents](#table-of-contents)
 
 # Golden Rules
 
-**1. Don't be a pedant**
+**1. Don't be a pedant.**<br />
 Don't be the type of person who fixates on minor details or meaningless trivia.
 
-**2. Don't be a gatekeeper**
+**2. Don't be a gatekeeper.**<br />
 _Gatekeeping_ is when someone takes it upon themselves to decide who does or does not have access to a community/identity. i.e. “You’re not a _real_ programmer if you don’t use [language x]”
 
-**3. Don't be cocky**
+**3. Don't be cocky.**<br />
 Always be humble. No one likes a cocky fool.
 
-**4. Maintain a student mentality**
+**4. Maintain a student mentality.**<br />
 Treat other members, regardless of their skill level, as though you have something to learn from them.
 
 In general, if you have a contribution to make, _please be encouraging_. Being pedantic or gatekeeping how "hard" something is or pretending like you're some kind of God when it comes to programming is purely reductive garbage. If you are found to be guilty of violating these tenants appropriate action shall be taken against you. There are far too many people out there actively discouraging self-improvement and learning. This server refuses to stand for it.
@@ -85,22 +85,22 @@ In general, if you have a contribution to make, _please be encouraging_. Being p
 
 Below is a list of things that you cannot talk about here. If a staff member cites you the content policy, please understand that they really mean _stop_ talking about the thing you are talking about. I think you will find the list reasonable, as we construct it to be conducive to an environment which suits talking about programming and technology in absence of distractions.
 
-**1. No politics, religion, philosophy or other such topics.**
+**1. No politics, religion, philosophy or other such topics.**<br />
 This goes without saying. You don't make friends by talking to strangers about these topics. Your political views have nothing to do with how good of a programmer you are.
 
-**2. No NSFW content in any capacity**
+**2. No NSFW content in any capacity.**<br />
 Always ask yourself "Would my boss be okay with this fullscreen on my monitor as he walked by?". If the answer is no, don't post it. The content here is meant to be pg13. Not pg15, not pg18 - if you wouldn't show it to your kid brother in front of your mother, it has no place here. No hentai, no porn, no anything like that.
 
-**3. No talk of suicide or depression**
+**3. No talk of suicide or depression.**<br />
 Sorry to say, but if you are depressed or considering suicide, that is terrible and we feel sorry for you, but we do **not** feel qualified to give advice, to moderate advice given, or anything of the sort. It would be absolutely unfair of me to put that weight on the shoulders of the moderators here. So please, ring your local suicide hotline which you can hopefully find here: [http://www.suicide.org/international-suicide-hotlines.html](http://www.suicide.org/international-suicide-hotlines.html "http://www.suicide.org/international-suicide-hotlines.html") (or by googling it)
 
-**4. No talk of illegal topics, pirating, reverse engineering, hacking, imitating user interaction or other similar topics**
+**4. No talk of illegal topics, pirating, reverse engineering, hacking, imitating user interaction or other similar topics.**<br />
 This includes anything against a sites terms of service, anything protected by a captcha/robots.txt and any automated account creation/checkout/purchasing. These topics are strictly forbidden. Topics related to these may also be disallowed.
 
-**5. Don't ask for relationship or life advice.**
+**5. Don't ask for relationship or life advice.**<br />
 As annoying as it is for me to write this, do not ask about how to "get the girl" or whatever. This is not the appropriate environment. Go look for dating advice and the like elsewhere. Complicated, heavy life advice topics that are not explicitly career related are **off limits** here as well. We're just programmers, we're not miracle makers.
 
-**6. Do not bring other server drama here.**
+**6. Do not bring other server drama here.**<br />
 We do not care that you got banned on another server. Sorry, but not our problem. Take it up with that server's staff.
 
 [Table of Contents](#table-of-contents)
@@ -113,10 +113,10 @@ _Hacking is a dick move. Stop trying to be a dick._
 
 It generally leads into even more illegal topics
 
-**So then, what is allowed?**
+**So then, what is allowed?**<br />
 Light talk about prevention is allowed. Providing elaborate details in any capacity of how someone might get past a system is not allowed.
 
-**Where should I ask?**
+**Where should I ask?**<br />
 Try not to, honestly, if you are looking to prevent a specific kind of attack feel free to ask if your code prevents that, outside of that sharing details as to how you might get past some code isn't the best idea, try to talk about the solution more so than the gory details of the problem. Feel free to share the gory details via DM, but don't wait to take the conversation to DM. This is one of the very few topic areas we want you to take it to DM, since information spread in this area is not something we want to prevent, rather, the discussion around it.
 
 [Table of Contents](#table-of-contents)
@@ -129,16 +129,16 @@ _Community-Member, Active Contributor, Chatterbox, Super-Talky-Guy, Bepis-Drinke
 
 These are the activity roles of the server. Different tiers will grant different perks, such unlocking hidden channels, voice access, and nicknaming privileges. These roles are assigned automatically as you participate in the server, so don't ask for them.
 
-**Wizard**
+**Wizard**<br />
 This is for helpful members who have shown exceptional aptitude or expertise in some field. This is given out on the discretion of Elliott - though other staff members may suggest someone to get it to Elliott. Less than 0.001% of users get this role.
 
-**Technology Champion**
+**Technology Champion**<br />
 These people will try to provide some answers on their own time for questions in the Technology spotlight category. Often times these people will write the introductory text for the current technology as well. Staff will be preferred for this role, but not always - This is a temporary role.
 
-**Solid Contributor**
+**Solid Contributor**<br />
 This role recognizes people who contribute their time and knowledge to the server completely out of their own volition.
 
-**Staff roles**
+**Staff roles**<br />
 Self-explanatory - _ChatMod/Moderator/Senior Moderator/Admin/Owner_ - These people ensure that the usage of this environment reflects the guidelines as illustrated in the rules. Staff are sometimes handpicked, and sometimes there is an application process. There is a trial period for all new staff of 2-4 weeks (Sometimes more, sometimes less) which comes with a trial role, however they are treated as full staff members during this time. Please respect all staff equally, however if you take issue with a specific staff member, talk to an administrator.
 
 [Table of Contents](#table-of-contents)
@@ -159,7 +159,7 @@ If you pipe up and get annoyed and flustered that you don't have your name, you'
 
 ModMail (@ModMail) is a bot which reports every direct message received to staff.
 
-**How do I use it?**
+**How do I use it?**<br />
 Send it a message. This will open a two-way communication medium between you and the entire staff team. It won't notify or bother people who are offline or busy, so don't even concern yourself with that part.
 
 **Use it when you...**
@@ -169,7 +169,7 @@ Send it a message. This will open a two-way communication medium between you and
 - Would like more context about a rule.
 - Would like to screen something with the staff before posting.
 
-**Don't use it when you...**
+**Don't use it when you...**<br />
 Notice something which requires immediate attention such as raids or NSFW content. In these cases, use the serious rule break tag instead to immediately alert staff.
 
 [Table of Contents](#table-of-contents)


### PR DESCRIPTION
# fix(rules): fix rule links and formatting

Currently, some of the links from the Table of Contents do not correctly link to the anchors in the page. It seems that the reason for this is that the links in the ToC are camel case, wheras the anchors in the Gatsby generated page are all lowercase. 

IE: 
`https://theprogrammershangout.com/rules#What-is-ModMail` vs `https://theprogrammershangout.com/rules#what-is-modmail`

This PR updates the links in the ToC to see if this will make it link to the correct section properly.

This PR also fixes title formatting to add a newline between the title and the content:
Before:
![image](https://user-images.githubusercontent.com/1348165/69252570-21a50f00-0bab-11ea-97c2-1b63eccffbe1.png)

After:
![image](https://user-images.githubusercontent.com/1348165/69252533-0f2ad580-0bab-11ea-840b-ed83e64f86da.png)

 