### PR TITLE
Fixed redirect links on resources 404

### DIFF
--- a/src/pages/resources/404.tsx
+++ b/src/pages/resources/404.tsx
@@ -96,7 +96,7 @@ function getPossibleResources(
         {displayArray.map((value, index) => {
           return (
             <li key={index}>
-              <Link to={`"resources/${value.node.relativePath}`}>
+              <Link to={`resources/${value.node.relativePath}`}>
                 {value.node.relativePath}
               </Link>
             </li>


### PR DESCRIPTION
During the TS type hint addition and slight refactoring, a stray quote was left in on PR https://github.com/the-programmers-hangout/website/pull/191. This quote would be in the redirection link, making the link invalid. 