### PR TITLE
Added a title and description for the index page

### DIFF
--- a/src/layouts/Layout/index.tsx
+++ b/src/layouts/Layout/index.tsx
@@ -4,6 +4,7 @@ import React, { FC, Fragment, useEffect } from "react"
 import { Container } from "../../components/Container"
 import { HomeFooter } from "../../components/HomeFooter"
 import { HomeHeader } from "../../components/HomeHeader"
+import { SEO } from "../../components/SEO"
 import { WavesBottom } from "../../components/Waves"
 import { GlobalStyles } from "../../globalStyles"
 import useLocation from "../../hooks/useLocation"
@@ -25,9 +26,18 @@ export const Layout: FC<RouteComponentProps> = ({ children }) => {
     <ThemeProvider>
       <SC.LayoutWrapper>
         <GlobalStyles />
-        <HomeHeader isHome={isHome} />
+        {isHome && (
+          <Fragment>
+            <SEO
+              title="Home"
+              description="The Programmer's Hangout (TPH) is a discord community geared towards programming."
+            />
+            <HomeHeader isHome={isHome} />
+          </Fragment>
+        )}
         {!isHome && (
           <Fragment>
+            <HomeHeader isHome={isHome} />
             <SC.MainContent>
               <Container>{children}</Container>
             </SC.MainContent>


### PR DESCRIPTION
I noticed the index page ([https://theprogrammershangout.com/](https://theprogrammershangout.com/)) doesn't have a title or description which is detrimental to the SEO of the site.

I have gone ahead and added them.

As you are not using the `index.tsx` file in `src/pages` I have just added on to how you have currently done it.