### PR TITLE
Fix svg waves across resolutions

### DIFF
--- a/src/components/Waves/styles.tsx
+++ b/src/components/Waves/styles.tsx
@@ -13,7 +13,7 @@ const waves = css`
 export const StyledWavesTop = styled(WavesTop)`
   ${waves};
   top: 0;
-  left: 0;
+  height: 87vh;
 `
 
 export const StyledWavesBottom = styled(WavesBottom)`

--- a/src/images/waves-bot.svg
+++ b/src/images/waves-bot.svg
@@ -30,10 +30,5 @@
       <stop offset=".51" stop-color="#FF70A5"/>
       <stop offset="1" stop-color="#FEAF6D"/>
     </linearGradient>
-    <linearGradient id="bot_gradient5" x1="1822.96" x2="1382.5" y1="1171.81" y2="-194.38" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#9423FC"/>
-      <stop offset=".51" stop-color="#FF70A5"/>
-      <stop offset="1" stop-color="#FEAF6D"/>
-    </linearGradient>
   </defs>
 </svg>

--- a/src/images/waves-bot.svg
+++ b/src/images/waves-bot.svg
@@ -1,4 +1,4 @@
-<svg fill="none" viewBox="0 0 1825 862" preserveAspectRatio="xMaxYmax slice">
+<svg fill="none" viewBox="0 0 1825 862" preserveAspectRatio="xMaxYMax slice">
   <mask id="#bot_mask" width="1825" height="862" x="0" y="0" maskUnits="userSpaceOnUse">
     <path fill="#C4C4C4" d="M0 0h1825v862H0z"/>
   </mask>

--- a/src/images/waves-top.svg
+++ b/src/images/waves-top.svg
@@ -1,4 +1,4 @@
-<svg fill="none" viewBox="0 0 1825 859" width="1825" height="859" preserveAspectRatio="xMinYMin meet">
+<svg fill="none" viewBox="0 0 1825 859" width="1825" height="859" preserveAspectRatio="xMaxYMin meet">
   <mask id="top_mask" width="1825" height="859" x="0" y="0" maskUnits="userSpaceOnUse">
     <path fill="#C4C4C4" d="M0 0h1825v859H0z"/>
   </mask>


### PR DESCRIPTION
As the title suggests. From #110 

Preview
[https://gyazo.com/1fe13849187a57d15b9d4ac4b50a25fe](https://gyazo.com/1fe13849187a57d15b9d4ac4b50a25fe)

It looks the same on mobile, and IE looks fine (albeit not identical to chrome / firefox)