### PR TITLE
404 Pages on Collections

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -170,6 +170,10 @@ exports.onCreatePage = async ({ page, actions }) => {
     const oldPage = { ...page }
     page.matchPath = `/resources/*`
     deletePage(oldPage)
+  } else if (page.path.match(/^\/archives\/404/)) {
+    const oldPage = { ...page }
+    page.matchPath = `/archives/*`
+    deletePage(oldPage)
   } else {
     page.context.layout = resolveLayout(page.path)
   }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -174,9 +174,9 @@ exports.onCreatePage = async ({ page, actions }) => {
     const oldPage = { ...page }
     page.matchPath = `/archives/*`
     deletePage(oldPage)
-  } else {
-    page.context.layout = resolveLayout(page.path)
   }
+
+  page.context.layout = resolveLayout(page.path)
   createPage(page)
 }
 

--- a/src/components/404LinkCorrection/index.tsx
+++ b/src/components/404LinkCorrection/index.tsx
@@ -58,7 +58,8 @@ function levenshteinDistance(term1: string, term2: string) {
 export const getPossibleCorrections = (
   basepath: string,
   location: WindowLocation,
-  data: { allFile: FileConnection }
+  data: { allFile: FileConnection },
+  threshold: number
 ) => {
   // the data prop has the graphql result
   // we're abstracting it to `linkArray` to just have array of edges matched
@@ -82,7 +83,7 @@ export const getPossibleCorrections = (
       levenshteinDistance(
         search.toLowerCase(),
         value.node!.relativePath!.toLowerCase()
-      ) < 8
+      ) < threshold
   )
 
   // helpful message if no matches found

--- a/src/components/404LinkCorrection/index.tsx
+++ b/src/components/404LinkCorrection/index.tsx
@@ -1,0 +1,108 @@
+import { WindowLocation } from "@reach/router"
+import { Link } from "gatsby"
+import React, { Fragment } from "react"
+
+import { FileConnection } from "../../../generated/graphql"
+
+// helper function to make matrix generation easier
+// credits to https://stackoverflow.com/a/13808461
+function makeMatrix(w: number, h: number, val: any = null) {
+  return Array(h)
+    .fill(null)
+    .map(() => Array(w).fill(val))
+}
+
+// calculate semantic difference
+// based on one character edits
+// efficient refactoring inspired by MIT licensed repo:
+// https://github.com/trekhleb/javascript-algorithms
+function levenshteinDistance(term1: string, term2: string) {
+  /* base case: empty strings */
+  if (term1.length === 0) {
+    return term2.length
+  }
+  if (term2.length === 0) {
+    return term1.length
+  }
+
+  // this will be our comparison matrix
+  const matrix = makeMatrix(term1.length + 1, term2.length + 1, null)
+
+  // make zeroeth row based off first term
+  for (let i = 0; i <= term1.length; i += 1) {
+    matrix[0][i] = i
+  }
+
+  // make zeroeth column based off second term
+  for (let j = 0; j <= term2.length; j += 1) {
+    matrix[j][0] = j
+  }
+
+  // iterative with full matrix implementation
+  // https://en.wikipedia.org/wiki/Levenshtein_distance
+  for (let j = 1; j <= term2.length; j += 1) {
+    for (let i = 1; i <= term1.length; i += 1) {
+      const substitutionCost = term1[i - 1] === term2[j - 1] ? 0 : 1
+
+      matrix[j][i] = Math.min(
+        matrix[j - 1][i] + 1, // deletion
+        matrix[j][i - 1] + 1, // insertion
+        matrix[j - 1][i - 1] + substitutionCost
+      ) // substitution
+    }
+  }
+
+  return matrix[term2.length][term1.length]
+}
+
+export const getPossibleCorrections = (
+  basepath: string,
+  location: WindowLocation,
+  data: { allFile: FileConnection }
+) => {
+  // the data prop has the graphql result
+  // we're abstracting it to `linkArray` to just have array of edges matched
+  // must use `.node.absolutePath` on each edge to get each node's absolute link
+  // we will compare this link
+  // however, the relative links are more user friendly
+  const linkArray = data.allFile.edges
+
+  // location prop has several attributes
+  // location.origin is base url
+  // location.href is the window location
+  // location.pathname is link after protocol and hostname
+  // by replacing `"/resources/"`,
+  // we are left with only the relative path to `resources`
+  const search = location.pathname.replace(`/${basepath}/`, "")
+
+  // filter based on distance
+  // levenshtein distance of x means how 'off' it was
+  const displayArray = linkArray.filter(
+    value =>
+      levenshteinDistance(
+        search.toLowerCase(),
+        value.node!.relativePath!.toLowerCase()
+      ) < 8
+  )
+
+  // helpful message if no matches found
+  const found = displayArray.length === 0 ? "Oops, nothing similar found." : ""
+
+  return (
+    <Fragment>
+      <h3>Based off of "{search}" you may have meant:</h3>
+      <ul>
+        {displayArray.map((value, index) => {
+          return (
+            <li key={index}>
+              <Link to={`${basepath}/${value.node.relativePath}`}>
+                {value.node.relativePath}
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+      {found}
+    </Fragment>
+  )
+}

--- a/src/components/404LinkCorrection/index.tsx
+++ b/src/components/404LinkCorrection/index.tsx
@@ -1,6 +1,6 @@
 import { WindowLocation } from "@reach/router"
 import { Link } from "gatsby"
-import React, { Fragment } from "react"
+import React, { FC, Fragment } from "react"
 
 import { FileConnection } from "../../../generated/graphql"
 
@@ -55,12 +55,19 @@ function levenshteinDistance(term1: string, term2: string) {
   return matrix[term2.length][term1.length]
 }
 
-export const getPossibleCorrections = (
-  basepath: string,
-  location: WindowLocation,
-  data: { allFile: FileConnection },
-  threshold: number
-) => {
+interface IPossibleCorrections {
+  basepath: string
+  location: WindowLocation
+  data: { allFile: FileConnection }
+  threshold?: number
+}
+
+export const PossibleCorrections: FC<IPossibleCorrections> = ({
+  basepath,
+  location,
+  data,
+  threshold = 8,
+}) => {
   // the data prop has the graphql result
   // we're abstracting it to `linkArray` to just have array of edges matched
   // must use `.node.absolutePath` on each edge to get each node's absolute link

--- a/src/components/404LinkCorrection/index.tsx
+++ b/src/components/404LinkCorrection/index.tsx
@@ -1,6 +1,6 @@
 import { WindowLocation } from "@reach/router"
-import { Link } from "gatsby"
 import React, { FC, Fragment } from "react"
+import * as SC from "./styles"
 
 import { FileConnection } from "../../../generated/graphql"
 
@@ -104,9 +104,9 @@ export const PossibleCorrections: FC<IPossibleCorrections> = ({
         {displayArray.map((value, index) => {
           return (
             <li key={index}>
-              <Link to={`${basepath}${value.node.relativePath}`}>
+              <SC.StyledLink to={`${basepath}${value.node.relativePath}`}>
                 {value.node.relativePath}
-              </Link>
+              </SC.StyledLink>
             </li>
           )
         })}

--- a/src/components/404LinkCorrection/index.tsx
+++ b/src/components/404LinkCorrection/index.tsx
@@ -78,13 +78,14 @@ export const getPossibleCorrections = (
 
   // filter based on distance
   // levenshtein distance of x means how 'off' it was
-  const displayArray = linkArray.filter(
-    value =>
+  const displayArray = linkArray.filter(value => {
+    return (
       levenshteinDistance(
         search.toLowerCase(),
         value.node!.relativePath!.toLowerCase()
       ) < threshold
-  )
+    )
+  })
 
   // helpful message if no matches found
   const found = displayArray.length === 0 ? "Oops, nothing similar found." : ""

--- a/src/components/404LinkCorrection/index.tsx
+++ b/src/components/404LinkCorrection/index.tsx
@@ -74,7 +74,7 @@ export const getPossibleCorrections = (
   // location.pathname is link after protocol and hostname
   // by replacing `"/resources/"`,
   // we are left with only the relative path to `resources`
-  const search = location.pathname.replace(`/${basepath}/`, "")
+  const search = location.pathname.replace(`/${basepath}`, "")
 
   // filter based on distance
   // levenshtein distance of x means how 'off' it was
@@ -96,7 +96,7 @@ export const getPossibleCorrections = (
         {displayArray.map((value, index) => {
           return (
             <li key={index}>
-              <Link to={`${basepath}/${value.node.relativePath}`}>
+              <Link to={`${basepath}${value.node.relativePath}`}>
                 {value.node.relativePath}
               </Link>
             </li>

--- a/src/components/404LinkCorrection/styles.tsx
+++ b/src/components/404LinkCorrection/styles.tsx
@@ -1,0 +1,16 @@
+import { Link } from "gatsby"
+import styled from "styled-components"
+
+export const StyledLink = styled(Link)`
+  color: #0090d8;
+  font-weight: 700;
+  border-bottom: 2px solid;
+  text-decoration: none;
+  transition: color 0.3s;
+
+  &:hover,
+  &:focus {
+    color: #5dbbea;
+    transition: none;
+  }
+`

--- a/src/pages/archives/404.tsx
+++ b/src/pages/archives/404.tsx
@@ -1,0 +1,32 @@
+import { Location } from "@reach/router"
+import { graphql } from "gatsby"
+import React, { Fragment } from "react"
+
+import { FileConnection } from "../../../generated/graphql"
+import { ComponentQuery } from "../../../typings"
+import { SEO } from "../../components/SEO"
+
+import { getPossibleCorrections } from "../../components/404LinkCorrection"
+
+export default ({ data }: ComponentQuery<{ allFile: FileConnection }>) => (
+  <Fragment>
+    <SEO title="404: Archive Not found" />
+    <h1>RESOURCE NOT FOUND</h1>
+    <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
+    <Location>
+      {({ location }) => getPossibleCorrections("archives/", location, data, 8)}
+    </Location>
+  </Fragment>
+)
+
+export const query = graphql`
+  query {
+    allFile(filter: { sourceInstanceName: { eq: "what-is-archive" } }) {
+      edges {
+        node {
+          relativePath
+        }
+      }
+    }
+  }
+`

--- a/src/pages/archives/404.tsx
+++ b/src/pages/archives/404.tsx
@@ -6,7 +6,7 @@ import { FileConnection } from "../../../generated/graphql"
 import { ComponentQuery } from "../../../typings"
 import { SEO } from "../../components/SEO"
 
-import { getPossibleCorrections } from "../../components/404LinkCorrection"
+import { PossibleCorrections } from "../../components/404LinkCorrection"
 
 export default ({ data }: ComponentQuery<{ allFile: FileConnection }>) => (
   <Fragment>
@@ -14,7 +14,13 @@ export default ({ data }: ComponentQuery<{ allFile: FileConnection }>) => (
     <h1>RESOURCE NOT FOUND</h1>
     <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
     <Location>
-      {({ location }) => getPossibleCorrections("archives/", location, data, 8)}
+      {({ location }) => (
+        <PossibleCorrections
+          basepath="archives/"
+          location={location}
+          data={data}
+        />
+      )}
     </Location>
   </Fragment>
 )

--- a/src/pages/archives/index.tsx
+++ b/src/pages/archives/index.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from "react"
 
-import { Link } from "../components/Link"
-import { SEO } from "../components/SEO"
+import { Link } from "../../components/Link"
+import { SEO } from "../../components/SEO"
 
 function ArchivesPage() {
   return (

--- a/src/pages/resources/404.tsx
+++ b/src/pages/resources/404.tsx
@@ -57,7 +57,8 @@ function levenshteinDistance(term1: string, term2: string) {
   return matrix[term2.length][term1.length]
 }
 
-function getPossibleResources(
+function getPossibleCorrections(
+  basepath: string,
   location: WindowLocation,
   data: { allFile: FileConnection }
 ) {
@@ -74,7 +75,7 @@ function getPossibleResources(
   // location.pathname is link after protocol and hostname
   // by replacing `"/resources/"`,
   // we are left with only the relative path to `resources`
-  const search = location.pathname.replace("/resources/", "")
+  const search = location.pathname.replace(`/${basepath}/`, "")
 
   // filter based on distance
   // levenshtein distance of x means how 'off' it was
@@ -96,7 +97,7 @@ function getPossibleResources(
         {displayArray.map((value, index) => {
           return (
             <li key={index}>
-              <Link to={`resources/${value.node.relativePath}`}>
+              <Link to={`${basepath}/${value.node.relativePath}`}>
                 {value.node.relativePath}
               </Link>
             </li>
@@ -114,7 +115,7 @@ export default ({ data }: ComponentQuery<{ allFile: FileConnection }>) => (
     <h1>RESOURCE NOT FOUND</h1>
     <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
     <Location>
-      {({ location }) => getPossibleResources(location, data)}
+      {({ location }) => getPossibleCorrections("resources", location, data)}
     </Location>
   </Fragment>
 )

--- a/src/pages/resources/404.tsx
+++ b/src/pages/resources/404.tsx
@@ -1,113 +1,11 @@
-import { Location, WindowLocation } from "@reach/router"
-import { graphql, Link } from "gatsby"
+import { Location } from "@reach/router"
+import { graphql } from "gatsby"
 import React, { Fragment } from "react"
 
 import { FileConnection } from "../../../generated/graphql"
 import { ComponentQuery } from "../../../typings"
+import { getPossibleCorrections } from "../../components/404LinkCorrection"
 import { SEO } from "../../components/SEO"
-
-// helper function to make matrix generation easier
-// credits to https://stackoverflow.com/a/13808461
-function makeMatrix(w: number, h: number, val: any = null) {
-  return Array(h)
-    .fill(null)
-    .map(() => Array(w).fill(val))
-}
-
-// calculate semantic difference
-// based on one character edits
-// efficient refactoring inspired by MIT licensed repo:
-// https://github.com/trekhleb/javascript-algorithms
-function levenshteinDistance(term1: string, term2: string) {
-  /* base case: empty strings */
-  if (term1.length === 0) {
-    return term2.length
-  }
-  if (term2.length === 0) {
-    return term1.length
-  }
-
-  // this will be our comparison matrix
-  const matrix = makeMatrix(term1.length + 1, term2.length + 1, null)
-
-  // make zeroeth row based off first term
-  for (let i = 0; i <= term1.length; i += 1) {
-    matrix[0][i] = i
-  }
-
-  // make zeroeth column based off second term
-  for (let j = 0; j <= term2.length; j += 1) {
-    matrix[j][0] = j
-  }
-
-  // iterative with full matrix implementation
-  // https://en.wikipedia.org/wiki/Levenshtein_distance
-  for (let j = 1; j <= term2.length; j += 1) {
-    for (let i = 1; i <= term1.length; i += 1) {
-      const substitutionCost = term1[i - 1] === term2[j - 1] ? 0 : 1
-
-      matrix[j][i] = Math.min(
-        matrix[j - 1][i] + 1, // deletion
-        matrix[j][i - 1] + 1, // insertion
-        matrix[j - 1][i - 1] + substitutionCost
-      ) // substitution
-    }
-  }
-
-  return matrix[term2.length][term1.length]
-}
-
-function getPossibleCorrections(
-  basepath: string,
-  location: WindowLocation,
-  data: { allFile: FileConnection }
-) {
-  // the data prop has the graphql result
-  // we're abstracting it to `linkArray` to just have array of edges matched
-  // must use `.node.absolutePath` on each edge to get each node's absolute link
-  // we will compare this link
-  // however, the relative links are more user friendly
-  const linkArray = data.allFile.edges
-
-  // location prop has several attributes
-  // location.origin is base url
-  // location.href is the window location
-  // location.pathname is link after protocol and hostname
-  // by replacing `"/resources/"`,
-  // we are left with only the relative path to `resources`
-  const search = location.pathname.replace(`/${basepath}/`, "")
-
-  // filter based on distance
-  // levenshtein distance of x means how 'off' it was
-  const displayArray = linkArray.filter(
-    value =>
-      levenshteinDistance(
-        search.toLowerCase(),
-        value.node!.relativePath!.toLowerCase()
-      ) < 8
-  )
-
-  // helpful message if no matches found
-  const found = displayArray.length === 0 ? "Oops, nothing similar found." : ""
-
-  return (
-    <Fragment>
-      <h3>Based off of "{search}" you may have meant:</h3>
-      <ul>
-        {displayArray.map((value, index) => {
-          return (
-            <li key={index}>
-              <Link to={`${basepath}/${value.node.relativePath}`}>
-                {value.node.relativePath}
-              </Link>
-            </li>
-          )
-        })}
-      </ul>
-      {found}
-    </Fragment>
-  )
-}
 
 export default ({ data }: ComponentQuery<{ allFile: FileConnection }>) => (
   <Fragment>

--- a/src/pages/resources/404.tsx
+++ b/src/pages/resources/404.tsx
@@ -4,7 +4,7 @@ import React, { Fragment } from "react"
 
 import { FileConnection } from "../../../generated/graphql"
 import { ComponentQuery } from "../../../typings"
-import { getPossibleCorrections } from "../../components/404LinkCorrection"
+import { PossibleCorrections } from "../../components/404LinkCorrection"
 import { SEO } from "../../components/SEO"
 
 export default ({ data }: ComponentQuery<{ allFile: FileConnection }>) => (
@@ -13,9 +13,13 @@ export default ({ data }: ComponentQuery<{ allFile: FileConnection }>) => (
     <h1>RESOURCE NOT FOUND</h1>
     <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
     <Location>
-      {({ location }) =>
-        getPossibleCorrections("resources/", location, data, 8)
-      }
+      {({ location }) => (
+        <PossibleCorrections
+          basepath="resources/"
+          location={location}
+          data={data}
+        />
+      )}
     </Location>
   </Fragment>
 )

--- a/src/pages/resources/404.tsx
+++ b/src/pages/resources/404.tsx
@@ -13,7 +13,7 @@ export default ({ data }: ComponentQuery<{ allFile: FileConnection }>) => (
     <h1>RESOURCE NOT FOUND</h1>
     <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
     <Location>
-      {({ location }) => getPossibleCorrections("resources", location, data)}
+      {({ location }) => getPossibleCorrections("resources", location, data, 8)}
     </Location>
   </Fragment>
 )

--- a/src/pages/resources/404.tsx
+++ b/src/pages/resources/404.tsx
@@ -13,7 +13,9 @@ export default ({ data }: ComponentQuery<{ allFile: FileConnection }>) => (
     <h1>RESOURCE NOT FOUND</h1>
     <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
     <Location>
-      {({ location }) => getPossibleCorrections("resources", location, data, 8)}
+      {({ location }) =>
+        getPossibleCorrections("resources/", location, data, 8)
+      }
     </Location>
   </Fragment>
 )


### PR DESCRIPTION
Abstracted the logic in the resources' 404 page to work on any given collection. Implemented it for the tech spotlights. It should be easy enough to add the special 404 to a new collection if one appears as well. 

A couple of notes:
- Not sure if the threshold (number of single characters edits needed to consider a url a viable candidate) is too high for tech spotlights (since tech spotlights have the extra `what-is-`)
- We may need to refactor `gatsby-node.js`'s `onCreatePage` later to use a switch
- I tried to use proper types, but those may require some review :sweat_smile: 