### PR TITLE
Fixing breadcrumbs 404 & Unique key prop warning on resource sidebar

### DIFF
--- a/src/components/Breadcrumb/index.tsx
+++ b/src/components/Breadcrumb/index.tsx
@@ -32,7 +32,7 @@ function flatten([
 export function Breadcrumb({ relativePath, basePath }: IBreadcrumbProps) {
   const paths = relativePath.split("/")
   const breadcrumbItems = flatten([traversePaths(paths, basePath)])
-  let count = 0;
+  let foldersDepth = 0;
   return (
     <SC.BreadcrumbWrapper>
       <SC.LinkWrapper>
@@ -55,8 +55,8 @@ export function Breadcrumb({ relativePath, basePath }: IBreadcrumbProps) {
 
       {breadcrumbItems.map(item => {
         if (item.type === "folder") {
-          count++;
-          if (count > 1) {
+          foldersDepth++;
+          if (foldersDepth > 1) {
             return (
             <SC.LinkWrapper key={item.path}>
               { item.title }

--- a/src/components/Breadcrumb/index.tsx
+++ b/src/components/Breadcrumb/index.tsx
@@ -32,7 +32,7 @@ function flatten([
 export function Breadcrumb({ relativePath, basePath }: IBreadcrumbProps) {
   const paths = relativePath.split("/")
   const breadcrumbItems = flatten([traversePaths(paths, basePath)])
-
+  let count = 0;
   return (
     <SC.BreadcrumbWrapper>
       <SC.LinkWrapper>
@@ -52,14 +52,25 @@ export function Breadcrumb({ relativePath, basePath }: IBreadcrumbProps) {
         />
         <ChevronUp />
       </SC.LinkWrapper>
+
       {breadcrumbItems.map(item => {
         if (item.type === "folder") {
-          return (
+          count++;
+          if (count > 1) {
+            return (
             <SC.LinkWrapper key={item.path}>
-              <Link item={item} />
+              { item.title }
               <ChevronUp />
             </SC.LinkWrapper>
-          )
+            )
+          } else {
+            return (
+              <SC.LinkWrapper key={item.path}>
+                <Link item={item} />
+                <ChevronUp />
+              </SC.LinkWrapper>
+            )
+          }
         }
 
         return (

--- a/src/components/ResourcesSidebar/index.tsx
+++ b/src/components/ResourcesSidebar/index.tsx
@@ -99,7 +99,7 @@ function Folder({ item }: { item: IFolder }) {
       </SC.Label>
       <SC.Children>
         {sortedChildren.map(node => (
-          <Tree item={node} />
+          <Tree key={node.title + '-tree'} item={node} />
         ))}
       </SC.Children>
     </SC.TreeWrapper>
@@ -120,7 +120,7 @@ const FirstLevelFolder = memo(({ item }: { item: IFolder }) => {
       <SC.FirstLabel>{humanize(item.title)}</SC.FirstLabel>
       <SC.Children>
         {sortedChildren.map(node => (
-          <Tree item={node} />
+          <Tree key={node.title + '-tree'} item={node} />
         ))}
       </SC.Children>
     </SC.TreeWrapper>


### PR DESCRIPTION
closes #198

Folders in resources that aren't the root folder have content.
[https://gyazo.com/2b0a2cee0c6b4ba586ad6384d85c010b](https://gyazo.com/2b0a2cee0c6b4ba586ad6384d85c010b)

To fix this I don't link the second or more folder when rendering the breadcrumbs (not the best solution but since we can't tell if an item's path exists it's the best I could come up with)

This is what it looks like after the fix

![image](https://user-images.githubusercontent.com/2869411/74319621-1d704280-4de4-11ea-8482-7a7c0c29633c.png)

I also noticed that there was this error relating to unique key props in the resource sidebar

![image](https://user-images.githubusercontent.com/2869411/74319665-30831280-4de4-11ea-9b23-504dc0c9ce4e.png)

and have fixed it accordingly.

Thanks