### PR TITLE
(content): remove who owns this server paragraph

### DIFF
--- a/src/content/site/about.md
+++ b/src/content/site/about.md
@@ -18,10 +18,6 @@ All you need to do is click. You'll be prompted to create yourself a Discord acc
 
 This server was made on the 4th of November, 2016.
 
-## Who owns this server?
-
-`Elliott#0001` and `Fox#0001`.
-
 ## Am I welcome?
 
 Anyone interested in discussing programming and not breaking the [rules](/rules) is welcome.


### PR DESCRIPTION
# (content): remove who owns this server paragraph

As discussed in Discord earlier, removing the "who owns this server" paragraph, as Fox's account is deleted now (and someone apparently took the name) and removing the paragraph seems like a good option to sort this issue.