### PR TITLE
Fixed unintentional code mistake in Javascript variables article

### DIFF
--- a/src/content/resources/javascript/variables.md
+++ b/src/content/resources/javascript/variables.md
@@ -117,7 +117,7 @@ console.log(myVar); // 'test'
 This is fixed using `let`
 
 ```js
-for('let i = 0; i < 5; i++) {
+for(let i = 0; i < 5; i++) {
   console.log(i);
 }
 console.log(i); // Error: i is undefined


### PR DESCRIPTION
This PR fixes what I believe is an unintentional mistake in one of the Javascript code snippets in the variables article - a misplaced apostrophe. The typo wouldn't make sense as an intentional, demonstrative mistake in the context of the article.