### PR TITLE
chore: remove now useless gatsby-plugin-typescript

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,7 +6,6 @@ module.exports = {
   },
   plugins: [
     `gatsby-plugin-react-helmet`,
-    `gatsby-plugin-typescript`,
     `gatsby-plugin-styled-components`,
     {
       resolve: `gatsby-plugin-prefetch-google-fonts`,

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "gatsby-plugin-react-svg": "^3.0.0",
     "gatsby-plugin-sharp": "^2.6.2",
     "gatsby-plugin-styled-components": "^3.3.1",
-    "gatsby-plugin-typescript": "^2.4.2",
     "gatsby-remark-auto-headers": "^1.0.3",
     "gatsby-remark-katex": "^3.3.1",
     "gatsby-source-filesystem": "^2.3.1",


### PR DESCRIPTION
As of https://github.com/gatsbyjs/gatsby/pull/23547 it's now included into Gatsby out of the box, so no longer necessary.