### PR TITLE
Fixed typos in chapter titles

### DIFF
--- a/src/content/resources/topic/projects/http-project-guide/chapter-12.md
+++ b/src/content/resources/topic/projects/http-project-guide/chapter-12.md
@@ -2,7 +2,7 @@
 authors:
   - "Kibb#4205"
 created_at: 2020/06/08
-title: "Chapter 11: Replying"
+title: "Chapter 12: Replying"
 ---
 
 ## Chapter 11: Replying.

--- a/src/content/resources/topic/projects/http-project-guide/chapter-13.md
+++ b/src/content/resources/topic/projects/http-project-guide/chapter-13.md
@@ -2,7 +2,7 @@
 authors:
   - "Kibb#4205"
 created_at: 2020/06/08
-title: "Chapter 12: Config"
+title: "Chapter 13: Config"
 ---
 
 ## Chapter 12: Config.


### PR DESCRIPTION
The chapter numbers in the titles of chapters 5, 12, and 13 were wrong. Just fixed the titles to show the correct chapter number.