### PR TITLE
Constrain Sidebar width

### DIFF
--- a/src/components/Sidebar/styles.tsx
+++ b/src/components/Sidebar/styles.tsx
@@ -12,7 +12,7 @@ export const SidebarWrapper = styled.div`
   position: fixed;
   top: 0;
   bottom: 0;
-  width: 320px;
+  max-width: 320px;
 
   @media screen and (max-width: 767px) {
     z-index: 100;
@@ -25,7 +25,7 @@ export const SidebarWrapper = styled.div`
 
   &.is-open {
     left: 0;
-    right: 100px;
+    right: 0;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
   }
 `


### PR DESCRIPTION
Reduce the size of the Sidebar when viewed in wide layouts

Before:
![SideBar-before](https://user-images.githubusercontent.com/7794722/92148867-2742ad00-edeb-11ea-922e-e763b6f32d9a.png)

After:
![SideBar-after](https://user-images.githubusercontent.com/7794722/92148940-44777b80-edeb-11ea-8e89-a4c9d5ca8fcc.png)

Matches width of desktop layout Sidebar:
![SideBar-desktop](https://user-images.githubusercontent.com/7794722/92148973-58bb7880-edeb-11ea-8638-7a64b97077f5.png)
