### PR TITLE
Prevent long TOC item overflow

### DIFF
--- a/src/components/PageContent/styles.tsx
+++ b/src/components/PageContent/styles.tsx
@@ -15,7 +15,7 @@ export const Content = styled.div`
 
 export const Sidebar = styled.div`
   width: 240px;
-  flex: 0 0 240px;
+  flex: 0 1 240px;
   border-left: 1px solid ${(props) => darken(0.1, props.theme.main.background)};
   color: ${(props) => (props.theme.name === "dark" ? "#f9f9f9" : "#172129")};
   margin: 64px 0;


### PR DESCRIPTION
You can observe this behavior by finding a page with long Table of Contents items and scrolling to the right.

Before:
![toc-overflow-before](https://user-images.githubusercontent.com/7794722/92285768-26854600-eed3-11ea-94e4-4cae863f3468.png)
After:
![toc-overflow-after](https://user-images.githubusercontent.com/7794722/92285776-2be29080-eed3-11ea-8e01-d5756624063b.png)
