### PR TITLE
Reposition underline for resource links

### DIFF
--- a/src/components/ResourcesHomeContent/styles.tsx
+++ b/src/components/ResourcesHomeContent/styles.tsx
@@ -67,10 +67,7 @@ export const Box = styled.div`
 
     &::after {
       position: absolute;
-      margin-top: -6px;
-      top: 50%;
       left: 100%;
-      margin-left: 10px;
       display: block;
       content: "";
       /* I would prefer a svg, but could not get it to work */


### PR DESCRIPTION
- Fixes #321 
- As far as I can tell, this does not break any other link styles.

Before:
![underline-before](https://user-images.githubusercontent.com/7794722/92333942-5eb59180-f057-11ea-93a5-650eb86d3663.png)
After:
![underline-after](https://user-images.githubusercontent.com/7794722/92333944-62491880-f057-11ea-87c1-d05dffe813c9.png)
