### PR TITLE
Make all sidebar horizontal rules even

### DIFF
--- a/src/components/ResourcesSidebar/styles.tsx
+++ b/src/components/ResourcesSidebar/styles.tsx
@@ -112,7 +112,6 @@ export const ExpandIcon = styled(Expand)`
 `
 
 export const ExpandResources = styled.div`
-  padding-right: 15px;
   margin-bottom: 20px;
 `
 

--- a/src/components/Sidebar/styles.tsx
+++ b/src/components/Sidebar/styles.tsx
@@ -68,7 +68,7 @@ export const Title = styled.div`
 `
 
 export const Inner = styled.div`
-  padding: 20px 0 30px 20px;
+  padding: 20px 20px 30px 20px;
 `
 
 export const Menu = styled.nav`


### PR DESCRIPTION
The horizontal rules were inconsistent before (two would go all the way to the edge while the other did not). This PR gives all horizontal rules an even gap to the right.

Before:
![sidebar-before](https://user-images.githubusercontent.com/7794722/92335294-e0132100-f063-11ea-8eb0-5a1ba6608b4a.png)

After:
![sidebar-after](https://user-images.githubusercontent.com/7794722/92335304-ebfee300-f063-11ea-81a2-00b5d4098322.png)
