### PR TITLE
Prevent sidebar title from changing colors

### DIFF
--- a/src/components/Sidebar/styles.tsx
+++ b/src/components/Sidebar/styles.tsx
@@ -59,7 +59,7 @@ export const Title = styled.div`
   display: flex;
   flex: 1 0 auto;
   align-items: center;
-  color: ${(props) => transparentize(0.1, props.theme.sidebar.foreground)};
+  color: rgba(255, 255, 255, 0.9);
   font-size: 20px;
   line-height: 24px;
   font-weight: 700;


### PR DESCRIPTION
**Changes:**
- Prevents sidebar title color from changing when switched to light mode
- Fixes #330 

Before:
![light-mode-title](https://user-images.githubusercontent.com/7794722/92418980-9ea07580-f138-11ea-8d04-c188082bbbee.png)

After:
![tph-title-light-mode-after](https://user-images.githubusercontent.com/7794722/92418986-a3fdc000-f138-11ea-8044-4068074cac58.png)
