### PR TITLE
Allow Home text color to toggle for light mode

### DIFF
--- a/src/components/Home/styles.tsx
+++ b/src/components/Home/styles.tsx
@@ -30,7 +30,7 @@ export const Title = styled.h1`
   font-size: 88px;
   text-transform: uppercase;
   line-height: 1;
-  color: #fff;
+  color: ${(props) => props.theme.main.foreground};
   text-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
   margin: 32px 0;
   max-width: 100%;
@@ -110,7 +110,7 @@ export const MenuItemLine = styled.div`
   width: 100%;
   margin-top: -3px;
   bottom: 0;
-  background: #fff;
+  background: ${(props) => props.theme.main.foreground};
   transition: all 0.3s;
   left: 0;
 `
@@ -120,7 +120,7 @@ export const menuItemStyles = css`
   align-items: center;
   font-size: 22px;
   text-decoration: none;
-  color: #fff;
+  color: ${(props) => props.theme.main.foreground};
   position: relative;
   transition: color 0.3s;
   margin: 10px 20px 5px 0;

--- a/src/components/HomePartner/styles.tsx
+++ b/src/components/HomePartner/styles.tsx
@@ -8,6 +8,7 @@ export const HomePartnerWrapper = styled.div`
   font-family: "Oxygen Mono", monospace;
   text-transform: uppercase;
   font-size: 22px;
+  color: ${(props) => props.theme.main.foreground};
 `
 
 export const StyledJetBrainsLogo = styled(JetBrainsLogo)`


### PR DESCRIPTION
**Changes:**
- Switches Home and HomePartner text and underline colors when light mode is enabled.
- Fixes #333 

Before:
![home-text-color-before](https://user-images.githubusercontent.com/7794722/92420201-01493f80-f140-11ea-9da3-96e27353610e.png)

After:
![home-text-color-after](https://user-images.githubusercontent.com/7794722/92420205-073f2080-f140-11ea-8988-9998ca4cd156.png)
