### PR TITLE
Center resource header box on firefox mobile layout

### DIFF
--- a/src/components/HeaderBarebone/styles.tsx
+++ b/src/components/HeaderBarebone/styles.tsx
@@ -101,6 +101,8 @@ export const Box = styled.div`
     bottom: auto;
     top: auto;
     margin: 32px 0;
+    left: 0px;
+    right: 0px;
 
     @-moz-document url-prefix() {
       & {


### PR DESCRIPTION
**Changes:**
- Sets `left` and `right` positions of component `Box` to `0px` for mobile layouts
- Fixes #341 

**Before:**
![tph-reource-header](https://user-images.githubusercontent.com/7794722/93273785-c0c47400-f786-11ea-949d-fd68af42ba0a.png)

**After:**
![tph-resource-header-after](https://user-images.githubusercontent.com/7794722/93273797-c91caf00-f786-11ea-955d-7084e4b0470b.png)
