### PR TITLE
Prevent spotlight link underlines from extending past text

### DIFF
--- a/src/components/ArchivesSidebar/styles.tsx
+++ b/src/components/ArchivesSidebar/styles.tsx
@@ -5,15 +5,14 @@ import styled from "styled-components"
 export const PageLink = styled(Link)`
   display: block;
   padding: 4px 0 0;
-  margin-bottom: 4px;
   color: ${(props) => props.theme.sidebar.foreground};
   align-self: flex-start;
   text-decoration: none;
-  border-bottom: 2px solid transparent;
 
   &:hover {
     border-color: ${(props) =>
       transparentize(0.7, props.theme.sidebar.foreground)};
+    text-decoration: underline;
   }
 
   & + & {


### PR DESCRIPTION
**Changes:**
- Converts link underline from `border-bottom` to `text-decoration`
- Fixes #344 

**Screenshots:**
Before:
![tph-spotlight-link](https://user-images.githubusercontent.com/7794722/93392105-36d7e200-f83e-11ea-9189-0ea08bdd3e77.png)
After:
![tph-reource-header-after](https://user-images.githubusercontent.com/7794722/93392120-3b03ff80-f83e-11ea-8951-1f648186b9f6.png)
