### PR TITLE
Prevent ToC from repositioning when zoom is <100%

### DIFF
--- a/src/components/PageContent/styles.tsx
+++ b/src/components/PageContent/styles.tsx
@@ -3,8 +3,7 @@ import fontFamily from "../../design/typography"
 import { darken } from "polished"
 
 export const Content = styled.div`
-  flex: 1 1 calc(100% - 305px);
-  width: calc(100% - 305px);
+  flex: 1 1 calc(1vw - 305px);
   padding: 64px 0;
 
   @media screen and (max-width: 1200px) {


### PR DESCRIPTION
**Changes:**
- Specify Content component width with `vw` units instead of a percentage
- Remove unnecessary `width` property
- Fix #349 

**Screenshots:**
Before:
![tph-sidebar-before](https://user-images.githubusercontent.com/7794722/93671657-cd8ce480-fa72-11ea-9678-225b649fb7ae.png)
After:
![tph-sidebar-after](https://user-images.githubusercontent.com/7794722/93671659-d5e51f80-fa72-11ea-9a8e-2de43c975525.png)

