### PR TITLE
fix: delete example token to prevent out of page margin

### DIFF
--- a/src/content/archives/what-is-discordjs.md
+++ b/src/content/archives/what-is-discordjs.md
@@ -62,12 +62,6 @@ Open up the `.env` file and fill it out using the information
 DISCORD_TOKEN=your_token
 ```
 
-// Example
-
-```
-DISCORD_TOKEN=NzEyNTgwNDYyMzAzOTAzODA2.XsToSQ.ef6y_53oQbNCpNsDgWoWu7QSPU4 (not a real token)
-```
-
 The `index.js` file is where all our code goes.
 Lets talk through getting the core of our bot running:
 


### PR DESCRIPTION
The long token in discord.js spotlight was messing up the margin due to the fact `` doesn't line break. Completely removed the example token as there's already a sufficient example above.