### PR TITLE
Add width property - fix toc positioning

### DIFF
--- a/src/components/PageContent/styles.tsx
+++ b/src/components/PageContent/styles.tsx
@@ -4,6 +4,7 @@ import { darken } from "polished"
 
 export const Content = styled.div`
   flex: 1 1 calc(1vw - 305px);
+  width: calc(100% - 305px);
   padding: 64px 0;
 
   @media screen and (max-width: 1200px) {


### PR DESCRIPTION
This PR fixes #352 

Before:
![before_toc](https://user-images.githubusercontent.com/40687700/94760694-deb5e980-03c0-11eb-861b-adf5384e8205.gif)

After:
![after_toc](https://user-images.githubusercontent.com/40687700/94760707-e7a6bb00-03c0-11eb-8efb-b362906451f9.gif)