### PR TITLE
Change `path.join` to `path.posix.join` ensuring path uses `/` not `\`

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -102,7 +102,7 @@ const createResources = async ({ createPage, graphql }) => {
     // create home page for each resources
     resources.forEach((resource) => {
       createPage({
-        path: path.join("resources", resource),
+        path: path.posix.join("resources", resource),
         component: resourceHome,
         context: {
           resourceType: key,
@@ -114,7 +114,7 @@ const createResources = async ({ createPage, graphql }) => {
 
     query.data.allFile.edges.forEach(({ node }) => {
       createPage({
-        path: path.join("resources", node.relativePath),
+        path: path.posix.join("resources", node.relativePath),
         component: resourcePage,
         context: {
           file: node.relativePath,
@@ -147,7 +147,7 @@ const createArchives = async ({ createPage, graphql }) => {
 
   return result.data.allFile.edges.forEach(({ node }) => {
     createPage({
-      path: path.join("archives", node.relativePath),
+      path: path.posix.join("archives", node.relativePath),
       component: archive,
       context: {
         file: node.relativePath,


### PR DESCRIPTION
This PR fixes #214 

`path.join` in Windows converts `/` in paths to `\`, so the path of those pages are converted to `/resources\javascript\iterative-vs-functional.md` but browsers can't use `\` in URL so it's redirected as 404 page.

`path.posix.join` ensures it's always use `/` regardless of OS.

Edit: Shoutout to my brother for lending me his PC.