### PR TITLE
Open resource intro on selecting

### DIFF
--- a/src/components/ResourcesSidebar/index.tsx
+++ b/src/components/ResourcesSidebar/index.tsx
@@ -160,8 +160,9 @@ const ResourceList: FC<{
   return (
     <SC.StyledResourceList>
       {items.map((item) => (
-        <SC.Resource
+        <SC.PageLink
           key={item.title}
+          to={getPath(item)}
           className={current === item.title ? "active" : ""}
           onClick={() => {
             setCurrent(item.title)
@@ -169,7 +170,7 @@ const ResourceList: FC<{
           }}
         >
           {item.title}
-        </SC.Resource>
+        </SC.PageLink>
       ))}
     </SC.StyledResourceList>
   )


### PR DESCRIPTION
This PR fixes #274 

Before: 
![before_resource_intro](https://user-images.githubusercontent.com/40687700/94772928-5c392400-03d8-11eb-950b-9516a4defc8f.gif)

After:
![after_resource_intro](https://user-images.githubusercontent.com/40687700/94772939-64915f00-03d8-11eb-8535-c8339dd17660.gif)

