### PR TITLE
Adds dotenv highlight support for Prism

### DIFF
--- a/src/components/Markdown/env.ts
+++ b/src/components/Markdown/env.ts
@@ -1,0 +1,34 @@
+import Prism from "prismjs"
+
+if (supportsLookBehind()) {
+    Prism.languages.env = {
+        property: {
+            pattern: /(.*.)(?==)/,
+        },
+        string: {
+            pattern: /(?<==)(.*.)/g,
+            global: true,
+        },
+        operator: {
+            pattern: /=/
+        }
+    }   
+} else {
+    Prism.languages.env = {
+        property: {
+            pattern: /(.*.)(?==)/,
+        },
+        operator: {
+            pattern: /=/
+        }
+    }
+}
+
+
+function supportsLookBehind() {
+    try {
+        return /(?<==)(.*)/.test("=hello")
+    } catch(e) {
+        return false;
+    }
+}

--- a/src/components/Markdown/index.tsx
+++ b/src/components/Markdown/index.tsx
@@ -16,6 +16,7 @@ import "prismjs/plugins/line-numbers/prism-line-numbers.css"
 import React, { FC, useEffect } from "react"
 import { MDXRenderer } from "gatsby-plugin-mdx"
 import * as SC from "./styles"
+import "./env";
 
 interface IMarkdownProps {
   content: string


### PR DESCRIPTION
Adds highlighting support for dotenv codeblocks. Fixes #367 


highlighting strings after `=` without capturing it requires positive lookahead, which isn't supported in all browsers, so I added a check just in case, but I wasn't able to define the `string` settings after defining `attribute` and `operator` separately, for some, reason adding `string`'s config afterwards wasn't working, so I had to repeat a little code in the if blocks.