### PR TITLE
Change source link of emourge in bots list

### DIFF
--- a/src/content/site/bots.md
+++ b/src/content/site/bots.md
@@ -238,7 +238,7 @@ Below are the bots you will see in the server but you will not need to interact 
 
 **Description:** Emourge tracks emote usage. We use this to help us identify the least used emotes incase we want to add some new ones!
 
-**Source:** https://github.com/dfireBird/emourge
+**Source:** https://github.com/dfireBird/emourge-mongo
 
 
 ## Hawk


### PR DESCRIPTION
The server uses mongo version of emourge but the current source points the postgres version.