### PR TITLE
Fix sticky navbar on mobile devices

### DIFF
--- a/src/components/HeaderBarebone/index.tsx
+++ b/src/components/HeaderBarebone/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react"
-import { useDebounce, useWindowScroll } from "react-use"
+import { useDebounce, useMotion, useWindowScroll } from "react-use"
 import cx from "classnames"
 
 import * as SC from "./styles"
@@ -74,6 +74,7 @@ export const HeaderBarebone = (props: IHeaderBareboneProps) => {
     10,
     [y]
   )
+  const deviceMotion = useMotion()
 
   useEffect(() => {
     return () => {
@@ -108,7 +109,7 @@ export const HeaderBarebone = (props: IHeaderBareboneProps) => {
           {!isBoxed && <SC.SingleTitle>{props.title}</SC.SingleTitle>}
         </Container>
       </SC.HeaderWrapper>
-      {scrollY >= 270 && stickyHeader}
+      {scrollY >= 270 && deviceMotion.acceleration.x == null && stickyHeader}
     </>
   )
 }


### PR DESCRIPTION
Resolves #421 with the use of gyroscopes which most mobile devices have nowadays. Since computers usually don't have them, those won't be impacted.

Another method would be to use [ua-parser-js](https://www.npmjs.com/package/ua-parser-js), which is only 6kB in size, but IMO this method should be tried out first. Works on my SM-A505F and both my laptops.