### PR TITLE
Fix accessibility violations: Add aria-labels to icon link

### DIFF
--- a/src/images/jetbrains-logo.tsx
+++ b/src/images/jetbrains-logo.tsx
@@ -1,11 +1,19 @@
 import React from "react"
 import useId from "../hooks/useId"
 
-const JetbrainsLogo: React.FC = (props) => {
+const JetbrainsLogo: React.FC<{ alt: string }> = ({ alt, ...props }) => {
   const id = useId()
+  const titleId = `jetbrains-logo-title-${id}`
 
   return (
-    <svg fill="none" viewBox="0 0 121 131" {...props}>
+    <svg
+      fill="none"
+      viewBox="0 0 121 131"
+      role="img"
+      aria-labelledby={titleId}
+      {...props}
+    >
+      <title id={titleId}>{alt}</title>
       <path
         fill={`url(#jetbrains1-${id})`}
         d="M118.62 71.8a4.68 4.68 0 00-6.2-7l-83.8 45.9a10.07 10.07 0 00-1.1 18c3.4 2 7.5 1.8 10.7-.2.2-.2.5-.3.7-.5l78-54.8c.4-.3 1.5-1.1 1.7-1.4z"


### PR DESCRIPTION


This PR fixes an accessibility (a11y) violation where the JetBrains logo within a link lacked a text alternative.

<img width="2560" height="920" alt="image" src="https://github.com/user-attachments/assets/2d100405-fa2e-4485-89ef-7220e5e3393c" />
Note: As shown in the provided diagnostic image, the checker flagged the element for lacking a text alternative. This patch resolves the issue by providing a dynamic alt text mapped to a title tag.

According to the IBM Equal Access Accessibility Checker, the previous implementation resulted in an empty link for screen reader users, as the nested SVG provided no descriptive context.

**Changes:**
Updated JetbrainsLogo component to accept an alt prop.

Added role="img" to the SVG element to explicitly define its semantic role.

Implemented aria-labelledby linked to a unique <title> element within the SVG to ensure screen readers correctly announce the logo's purpose.