### PR TITLE
docs: add design guidelines, design-engineer principles, and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# CLAUDE.md
+
+Guidance for AI agents (and humans) working in this repository.
+
+## Stack
+
+Gatsby + TypeScript + styled-components, with light/dark theming. Content lives in
+`src/content/` (Markdown); UI in `src/components`, `src/layouts`, `src/templates`.
+
+## Before you touch the UI
+
+Read **`docs/design/web-interface-guidelines.md`** — a per-PR checklist covering
+interactivity, motion, accessibility, color, and performance — and
+**`docs/design/design-engineer.md`** for how we approach design work here.
+
+Two rules that matter most:
+
+1. **Don't change the visual design without sign-off.** Behind-the-scenes quality
+   (accessibility, motion safety, performance, semantics, mobile feel) is fair
+   game. Anything that alters layout, color, type scale, or spacing is a design
+   change — confirm first.
+2. **Ship green, one improvement per commit.** `npm run lint` and `npm run build`
+   must pass. Use conventional commit messages.
+
+## Enforced automatically
+
+`.eslintrc.js` blocks, in styled-components CSS, `transition: all`, bare `:focus`
+(use `:focus-visible`), and `outline: none/0` without a focus replacement. CI runs
+`npm run lint`.
+
+## Commands
+
+- `npm run develop` — local dev server
+- `npm run build` — production build (the CI/Netlify gate)
+- `npm run lint` / `npm run lint:fix`
+- `npm run format` — Prettier

--- a/docs/design/design-engineer.md
+++ b/docs/design/design-engineer.md
@@ -1,0 +1,44 @@
+# Design Engineer — operating principles
+
+> Adapted from Vercel's "Design Engineer" page (https://vercel.com/design/engineer).
+
+## Mindset
+
+- **Obsess over usefulness.** Solve a real problem; make the solution feel obvious.
+- **Own the whole surface.** Strategy, interface, code, docs, and follow-up are one job.
+- **Understand constraints before choosing.** Users, product, code, and business shape the right answer.
+- **Design across skill, ability, and context.** Advanced capability is available, never mandatory.
+- **Scope small enough to execute excellently.** A tight slice done with craft beats a broad one done roughly.
+- **Push back when clarity, craft, performance, or trust is at risk.**
+- **Be kind, direct, low-ego.** Share early, give specific feedback.
+- **Convert recurring feedback into better defaults and systems** — fix the class, not the instance.
+
+## How that translates to THIS repo
+
+This is a Gatsby + styled-components content site. "Design engineering" here means
+raising baseline quality on every surface we touch without redesigning it:
+
+1. **Don't change the visual design without sign-off.** Behind-the-scenes craft
+   (a11y, motion safety, performance, semantics, mobile feel) is fair game and
+   should be improved continuously. Anything that alters layout, color, type
+   scale, or spacing is a design change — confirm first.
+2. **Fix the class via shared primitives.** Prefer a fix in `globalStyles`,
+   `src/design/`, or a shared component over the same fix copy-pasted into N
+   component `styles.tsx` files.
+3. **Every change ships green.** `npm run lint` and `npm run build` pass; one
+   logical improvement per commit with a conventional message.
+4. **Leave the guideline checklist greener than you found it.** See
+   `web-interface-guidelines.md`.
+
+## Enforcement ladder (weakest → strongest)
+
+Prose like this file is the *weakest* form of enforcement — agents must choose to
+read it. Stronger, in order:
+
+1. **Context injection** — `CLAUDE.md` references these files so they load every session. ✅ done
+2. **Lint rules** — the mechanical rules (`no transition: all`, `:focus` → `:focus-visible`, `outline: none` guard) are ESLint `no-restricted-syntax` checks in `.eslintrc.js`, so CI blocks violations. ✅ done
+3. **A `/design-review` skill / check** — runs the non-mechanical checklist (hit-target sizes, contrast, empty/error states) against a diff. ⬜ todo
+4. **CI gates / visual regression** — block merge on lint + a11y (axe) + Lighthouse budgets. ⬜ todo
+
+The goal: turn as many of the prose checklist items as possible into items 2–4,
+and keep the existing violations at zero.

--- a/docs/design/web-interface-guidelines.md
+++ b/docs/design/web-interface-guidelines.md
@@ -1,0 +1,97 @@
+# Web Interface Guidelines
+
+> Adapted from Vercel's Web Interface Guidelines (https://vercel.com/design/guidelines)
+> for this repo: **Gatsby + TypeScript + styled-components**, light/dark theming.
+>
+> Treat every checkbox as a rule to satisfy or consciously waive — not a suggestion.
+> Some of these are enforced automatically (see "Enforcement" at the bottom).
+
+## How to use this in a PR
+
+Before opening a PR that touches anything under `src/`, run the relevant section
+below as a checklist. A change that violates one of these without a stated reason
+should be fixed, not merged.
+
+---
+
+## Interactivity
+
+- [ ] Hit targets ≥ 24px (≥ 44px on mobile). Expand small visual targets with padding or a pseudo-element, don't shrink the click area.
+- [ ] No dead zones: the whole visual extent of an interactive element is clickable.
+- [ ] `touch-action: manipulation` on tappable elements to kill the 300ms mobile tap delay.
+- [ ] `-webkit-tap-highlight-color` set intentionally (transparent unless the design wants the flash).
+- [ ] Use `:focus-visible`, not `:focus`, for focus rings — keyboard users get the ring, mouse users don't.
+- [ ] Every focusable element has a **visible** focus ring. Never `outline: none` without a replacement.
+- [ ] Keyboard-operable: every flow works without a mouse, following WAI-ARIA Authoring Patterns.
+- [ ] Disabled/destructive actions get confirmation or undo.
+
+## Animation & motion
+
+- [ ] **Never `transition: all`** — list only the properties you animate.
+- [ ] Animate `transform` / `opacity` only (GPU). Avoid animating `width`, `height`, `top`, `left`, `background-size` for performance-critical paths.
+- [ ] Provide a `prefers-reduced-motion: reduce` variant. There is a global guard in `src/globalStyles.tsx`; still take per-component care.
+- [ ] CSS animation > Web Animations API > JS libraries, in that order.
+- [ ] Animations are interruptible by user input; no autoplay-driven motion.
+- [ ] SVG: apply transforms to a `<g>` wrapper with `transform-box: fill-box`.
+
+## Typography
+
+- [ ] Curly quotes (" ") over straight; `…` over `...`.
+- [ ] `font-variant-numeric: tabular-nums` anywhere numbers are compared or change in place (counts, stats, timers).
+- [ ] `&nbsp;` between a number and its unit (`10&nbsp;MB`).
+- [ ] Tidy rag — avoid widows/orphans in headings.
+
+## Color & contrast
+
+- [ ] `color-scheme` set to match the active theme (so native scrollbars/form controls match). Bound globally to `theme.name`.
+- [ ] `<meta name="theme-color">` matches the page background per theme (set in `src/ThemeProvider.tsx`).
+- [ ] Interactive states (hover/active/focus) have **more** contrast than rest.
+- [ ] Don't rely on color alone — pair with text/icon/shape.
+- [ ] On non-neutral backgrounds, tint borders/shadows/text toward the same hue.
+
+## Forms (when we add any)
+
+- [ ] Every control has a `<label>` (or `aria-label`).
+- [ ] Inputs are ≥16px font on mobile (or set `maximum-scale`) to prevent auto-zoom.
+- [ ] Never disable paste; never block typing; show validation instead of pre-disabling submit.
+- [ ] `autocomplete` + meaningful `name`; `autocomplete="one-time-code"` for OTP.
+- [ ] Spellcheck off for emails, codes, usernames.
+- [ ] Errors shown adjacent to the field; focus first error on submit.
+
+## Content & state
+
+- [ ] Design empty, sparse, dense, long, and error states — not just the happy path.
+- [ ] Skeletons mirror final layout to avoid shift; set explicit image dimensions.
+- [ ] No dead ends — every screen offers a next step or recovery.
+- [ ] Page `<title>` reflects current context.
+- [ ] Anchored headings set `scroll-margin-top` so deep links don't hide under sticky headers.
+- [ ] `translate="no"` on brand names and code tokens.
+
+## Accessibility
+
+- [ ] Semantics first: `button` / `a` / `label` / `table` before `role`/`aria-*`.
+- [ ] Hierarchical `<h1>`–`<h6>`; provide a skip link (the content layout has one).
+- [ ] Icon-only buttons get a descriptive `aria-label`.
+- [ ] `aria-live="polite"` for async toasts / inline validation.
+
+## Performance
+
+- [ ] Virtualize large lists; `content-visibility: auto` for long static content.
+- [ ] Preload critical fonts; subset via `unicode-range`.
+- [ ] Explicit image dimensions to prevent CLS (Gatsby Image handles most of this — verify).
+
+---
+
+## Enforcement
+
+The mechanical rules are encoded as ESLint `no-restricted-syntax` checks in
+`.eslintrc.js` and fail CI on regression:
+
+- `transition: all` is banned.
+- bare `:focus` (use `:focus-visible`) is banned.
+- `outline: none` / `outline: 0` is banned (add a visible focus replacement, or
+  disable the rule on that line with a justification).
+
+Everything else in this file is reviewed by humans (and agents — see
+`design-engineer.md`). The aim over time is to push more of this list down into
+lint rules, a `/design-review` check, and CI gates (axe, Lighthouse budgets).


### PR DESCRIPTION
Adds design reference docs to the repo (previously kept only as a local working copy under the gitignored `.context/`), plus a `CLAUDE.md` to wire them into agent sessions.

## What's here
- **`docs/design/web-interface-guidelines.md`** — a per-PR checklist adapted from [Vercel's Web Interface Guidelines](https://vercel.com/design/guidelines), tuned to this Gatsby + styled-components stack (interactivity, motion, a11y, color, content/state, performance).
- **`docs/design/design-engineer.md`** — operating principles from [Vercel's Design Engineer page](https://vercel.com/design/engineer), plus the **enforcement ladder** (prose → context-injection → lint → CI gates).
- **`CLAUDE.md`** — points agents (and humans) at the two docs and states the two load-bearing rules: don't change visual design without sign-off; ship green, one improvement per commit.

## Why
Prose guidelines are the weakest form of enforcement — an agent has to choose to read them. `CLAUDE.md` makes them load every session, and the mechanical rules are already enforced in `.eslintrc.js` (a companion change on the website branch) so CI blocks `transition: all`, bare `:focus`, and unguarded `outline: none`.

## Notes
- Docs-only; no code or build impact.
- The `CLAUDE.md` is the only opinionated addition — if you'd rather land just the two docs, drop that file and the PR still stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)